### PR TITLE
Try to make it possible to use other dotfiles with Arch installer

### DIFF
--- a/install_apps.sh
+++ b/install_apps.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /github_defaults
+
 name=$(cat /tmp/user_name)
 
 dry_run=${dry_run:-false}
@@ -16,7 +18,7 @@ do
 done
 
 apps_path="/tmp/apps.csv"
-curl https://raw.githubusercontent.com/Phantas0s/ArchInstall/master/apps.csv > $apps_path
+curl https://raw.githubusercontent.com/$GITHUB_INSTALLER_USER/$GITHUB_INSTALLER_NAME/master/apps.csv > $apps_path
 
 function pacman_install() {
     ((pacman --noconfirm --needed -S "$1" &>> "$output") || echo "$1" &>> /tmp/aur_queue);
@@ -132,8 +134,8 @@ echo "$final_apps" | while read -r line; do
     fi
 done
 
-curl https://raw.githubusercontent.com/Phantas0s/ArchInstall/master/install_user.sh > /tmp/install_user.sh;
-curl https://raw.githubusercontent.com/Phantas0s/ArchInstall/master/sudoers > /etc/sudoers
+curl https://raw.githubusercontent.com/$GITHUB_INSTALLER_USER/$GITHUB_INSTALLER_NAME/master/install_user.sh > /tmp/install_user.sh;
+curl https://raw.githubusercontent.com/$GITHUB_INSTALLER_USER/$GITHUB_INSTALLER_NAME/master/sudoers > /etc/sudoers
 
 dialog --infobox "Copy user permissions configuration (sudoers)..." 4 40
 if [ "$dry_run" = false ]; then

--- a/install_chroot.sh
+++ b/install_chroot.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /github_defaults
+
 uefi=$(cat /var_uefi) && hd=$(cat /var_hd)
 
 cat /hostname > /etc/hostname
@@ -66,5 +68,5 @@ config_user
 echo "$name" > /tmp/user_name
 
 dialog --title "Continue installation" --yesno "Do you want to install all the softwares and the dotfiles?" 10 60 \
-    && curl -LO https://raw.githubusercontent.com/Phantas0s/ArchInstall/master/install_apps.sh \
+    && curl -LO https://raw.githubusercontent.com/$GITHUB_INSTALLER_USER/$GITHUB_INSTALLER_NAME/master/install_apps.sh \
     && bash ./install_apps.sh

--- a/install_sys.sh
+++ b/install_sys.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Defaults related to Git repositories
+GITHUB_INSTALLER_USER=Phantas0s
+GITHUB_INSTALLER_NAME=ArchInstall
+GITHUB_DOTFILES_USER=Phantas0s
+GITHUB_DOTFILES_NAME=.dotfiles
+
+
 dry_run=${dry_run:-false}
 # TODO redirect output?
 output=${output:-/tmp/arch-install-logs}
@@ -22,6 +29,18 @@ dialog --defaultno \
     It will just DESTROY EVERYTHING on the hard disk of your choice. \n\n\
     Don't say YES if you are not sure about what you're doing! \n\n\
     Are you sure?"  15 60 || exit
+
+# Change and save defaults to a file so we can load
+# Defaults for Installer
+dialog --no-cancel --inputbox "Enter name of GitHub user for installer." 10 60 "$GITHUB_INSTALLER_USER" 2> temp_text
+GITHUB_INSTALLER_USER=$(cat temp_text) && rm temp_text
+dialog --no-cancel --inputbox "Enter name of GitHub project for installer." 10 60 "$GITHUB_INSTALLER_NAME" 2> temp_text
+GITHUB_INSTALLER_NAME=$(cat temp_text) && rm temp_text
+# Defaults for Dotfiles
+dialog --no-cancel --inputbox "Enter name of GitHub user for dotfiles." 10 60 "$GITHUB_DOTFILES_USER" 2> temp_text
+GITHUB_DOTFILES_USER=$(cat temp_text) && rm temp_text
+dialog --no-cancel --inputbox "Enter name of GitHub project for dotfiles." 10 60 "$GITHUB_DOTFILES_NAME" 2> temp_text
+GITHUB_DOTFILES_NAME=$(cat temp_text) && rm temp_text
 
 dialog --no-cancel --inputbox "Enter a name for your computer." 10 60 2> hn
 hostname=$(cat hn) && rm hn
@@ -122,15 +141,20 @@ genfstab -U /mnt >> /mnt/etc/fstab
 echo "$uefi" > /mnt/var_uefi
 echo "$hd" > /mnt/var_hd
 echo "$hostname" > /mnt/hostname
+echo 'export GITHUB_INSTALLER_USER='"$GITHUB_INSTALLER_USER" >/mnt/github_defaults
+echo 'export GITHUB_INSTALLER_NAME='"$GITHUB_INSTALLER_NAME" >>/mnt/github_defaults
+echo 'export GITHUB_DOTFILES_USER='"$GITHUB_DOTFILES_USER" >>/mnt/github_defaults
+echo 'export GITHUB_DOTFILES_NAME='"$GITHUB_DOTFILES_NAME" >>/mnt/github_defaults
 
 ### Continue installation
-curl https://raw.githubusercontent.com/Phantas0s/ArchInstall/master/install_chroot.sh > /mnt/install_chroot.sh
+curl https://raw.githubusercontent.com/$GITHUB_INSTALLER_USER/$GITHUB_INSTALLER_NAME/master/install_chroot.sh > /mnt/install_chroot.sh
 arch-chroot /mnt bash install_chroot.sh
 
 rm /mnt/var_uefi
 rm /mnt/var_hd
 rm /mnt/install_chroot.sh
 rm /mnt/hostname
+rm /mnt/github_defaults
 
 fi
 

--- a/install_user.sh
+++ b/install_user.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /github_defaults
+
 mkdir -p "/home/$(whoami)/Documents"
 mkdir -p "/home/$(whoami)/Downloads"
 
@@ -54,7 +56,7 @@ DOTFILES="/home/$(whoami)/.dotfiles"
 if [ ! -d "$DOTFILES" ];
     then
         dialog --infobox "[$(whoami)] Downloading .dotfiles..." 10 60
-        git clone --recurse-submodules https://github.com/Phantas0s/.dotfiles.git "$DOTFILES" >/dev/null
+        git clone --recurse-submodules https://github.com/$GITHUB_DOTFILES_USER/"$GITHUB_DOTFILES_NAME".git "$DOTFILES" >/dev/null
 fi
 
 source "/home/$(whoami)/.dotfiles/zsh/zshenv"


### PR DESCRIPTION
Hi, this is the PR I was talking about, it should ask you via Dialogs what the repositories are for both the Arch Installer and for the Dotfiles. Being able to specify the Dotfiles is especially important since people can reuse the installer with their dotfiles.