### PR TITLE
fix typo in bat description

### DIFF
--- a/apps.csv
+++ b/apps.csv
@@ -41,7 +41,7 @@ tools,imagemagick,Convert edit or compose images
 tools,unclutter,Hide the mouse after short period of time
 tools,pv,Display progress bar through pipeline
 tools,the_silver_searcher,A fast code searching tool
-tools,bat,A cat clone with winds
+tools,bat,A cat clone with wings
 tools,noto-fonts-cjk,Fonts for asian display
 tools,noto-fonts-emoji,Fonts for emojis
 tools,whois,Display web domain information


### PR DESCRIPTION
Hello, thanks for your installer!
You've made a typo in the `bat` description (see [bat](https://github.com/sharkdp/bat)) ☺️
Have a nice day!